### PR TITLE
Update .gitmodules. Fix path to submodule with qt-creator

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "qt-creator"]
 	path = qt-creator
-	url = https://github.com/qtproject/qt-creator.git
+	url = ../../qt-creator/qt-creator.git


### PR DESCRIPTION
Qt github organization were renamed from qtproject to qt-creator. Maybe it's better to use current namings. And when someone cloning youre repo through ssh then submodules are downloaded by https. It's not always possible to use such ways